### PR TITLE
build: simplify releases

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -22,15 +22,18 @@ jobs:
   lint:
     name: Lint
     uses: ./.github/workflows/lint.yml
+    with:
+      continue-on-error: true
 
   test:
     name: Test
     uses: ./.github/workflows/test.yml
+    with:
+      continue-on-error: true
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [lint, test]
     concurrency: ${{ github.workflow }}-release
 
     outputs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,18 @@ name: Lint
 
 "on":
   workflow_call:
+    inputs:
+      continue-on-error:
+        type: boolean
+        description: Allow a workflow run to pass when this workflow fails
+        required: false
+        default: false
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    continue-on-error: ${{ inputs.continue-on-error }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,18 @@ name: Test
 
 "on":
   workflow_call:
+    inputs:
+      continue-on-error:
+        type: boolean
+        description: Allow a workflow run to pass when this workflow fails
+        required: false
+        default: false
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    continue-on-error: ${{ inputs.continue-on-error }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This simplifies releases by not requiring `test` and `lint` since we have enabled
the GitHub setting "Require branches to be up to date before merging".

See: https://github.com/actions/runner/issues/1492#issuecomment-1031669824