### PR TITLE
build: allow latest semantic-release

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -71,14 +71,6 @@ semver-coerced\
       automerge: false
     },
     {
-      description: "Limit semantic-release versions to 19.x.x.\
-      Version 20.0.0 is not currently compatible with\
-      cycjimmy/semantic-release-action",
-      matchDatasources: ["npm"],
-      matchPackageNames: ["semantic-release"],
-      allowedVersions: "<= 19"
-    },
-    {
       description: "Limit gradle-semantic-release-plugin versions to 1.7.4.\
       Version 1.7.5 is currently only compatible with semantic-release >= 20",
       matchDatasources: ["npm"],


### PR DESCRIPTION
conventional-changelog v7 is only compatible with semantic-release v22+.
Previously semantic-release v20+ was not compatible with
cycjimmy/semantic-release-action but this has now been fixed.

Therefore upgrading semantic-release to latest should fix the release
tagging.

See:

- https://github.com/cycjimmy/semantic-release-action/issues/176
- https://github.com/semantic-release/semantic-release/issues/2978
- https://github.com/semantic-release/semantic-release/issues/2929