### PR TITLE
build: limit semantic-release to 21.x.x

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -16,7 +16,7 @@ env:
   CONVENTIONAL_CHANGELOG_CONVENTIONALCOMMITS_VERSION: 7.0.2
 
   # renovate: datasource=npm depName=gradle-semantic-release-plugin
-  GRADLE_SEMANTIC_RELEASE_PLUGIN_VERSION: 1.7.4
+  GRADLE_SEMANTIC_RELEASE_PLUGIN_VERSION: 1.7.7
 
 jobs:
   lint:
@@ -71,7 +71,7 @@ jobs:
           GIT_COMMITTER_EMAIL: 103840025+aki-bot[bot]@users.noreply.github.com
         with:
           # renovate: datasource=npm depName=semantic-release
-          semantic_version: 22.0.5
+          semantic_version: 21.0.2
           extra_plugins:
             "@semantic-release/changelog@\
             ${{ env.SEMANTIC_RELEASE_CHANGELOG_VERSION }} \

--- a/renovate.json5
+++ b/renovate.json5
@@ -71,11 +71,12 @@ semver-coerced\
       automerge: false
     },
     {
-      description: "Limit gradle-semantic-release-plugin versions to 1.7.4.\
-      Version 1.7.5 is currently only compatible with semantic-release >= 20",
+      description: "Limit semantic-release versions to 21.x.x.\
+      Version 22.0.0 is not currently compatible with\
+      gradle-semantic-release-plugin",
       matchDatasources: ["npm"],
-      matchPackageNames: ["gradle-semantic-release-plugin"],
-      allowedVersions: "<= 1.7.4"
+      matchPackageNames: ["semantic-release"],
+      allowedVersions: "<= 21"
     },
     {
       description: "Use correct compatibility for github/super-linter",


### PR DESCRIPTION
Version 22.0.0 is not currently compatible with
gradle-semantic-release-plugin